### PR TITLE
Fix basePath TMF672-UserRolePermission-v4.0.0.swagger.json

### DIFF
--- a/TMF672-UserRolePermission-v4.0.0.swagger.json
+++ b/TMF672-UserRolePermission-v4.0.0.swagger.json
@@ -6,7 +6,7 @@
         "version": "4.0.0"
     },
     "host": "serverRootserverRoot",
-    "basePath": "/payment/v4/",
+    "basePath": "/usersandroles/v4/",
     "schemes": [
         "https"
     ],


### PR DESCRIPTION
I fixed the basePath, which was wrong. Source for the correct basePath -> https://tmf-open-api-table-documents.s3.eu-west-1.amazonaws.com/OpenApiTable/4.0.0/user_guides/TMF672_User_Roles_and_Permissions_API_REST_Specification_R17.0.1.pdf